### PR TITLE
Further updates needed for ASP.NET Core to work

### DIFF
--- a/src/mono/wasi/mono-wasi-driver/driver.c
+++ b/src/mono/wasi/mono-wasi-driver/driver.c
@@ -251,6 +251,14 @@ int32_t SystemNative_Stat2(const char* path, FileStatus* output)
 		? 0x4000  // Dir
 		: 0x8000; // File
 
+	// Never fail when looking for the root directory. Even if the WASI host isn't giving us filesystem access
+	// (which is the default), we need the root directory to appear to exist, otherwise things like ASP.NET Core
+	// will fail by default, whether or not it needs to read anything from the filesystem.
+	if (ret != 0 && path[0] == '/' && path[1] == NULL) {
+		output->Mode = 0x4000; // Dir
+		return 0;
+	}
+
 	//printf("SystemNative_Stat2 for %s has ISDIR=%i and will return mode %i; ret=%i\n", path, S_ISDIR (stat_result.st_mode), output->Mode, ret);
 
 	return ret;

--- a/src/mono/wasi/mono-wasi-driver/driver.c
+++ b/src/mono/wasi/mono-wasi-driver/driver.c
@@ -324,6 +324,15 @@ static PinvokeImport SystemGlobalizationNativeImports [] = {
 	{NULL, NULL}
 };
 
+int SystemCryptoNativeBrowser_CanUseSubtleCryptoImpl() {
+	return 0;
+}
+
+static PinvokeImport SystemSecurityCryptographyNativeBrowserImports [] = {
+	{"SystemCryptoNativeBrowser_CanUseSubtleCryptoImpl", SystemCryptoNativeBrowser_CanUseSubtleCryptoImpl },
+	{NULL, NULL}
+};
+
 static void*
 wasm_dl_load (const char *name, int flags, char **err, void *user_data)
 {
@@ -331,6 +340,9 @@ wasm_dl_load (const char *name, int flags, char **err, void *user_data)
 		return SystemNativeImports;
 	if (!strcmp (name, "libSystem.Globalization.Native"))
 		return SystemGlobalizationNativeImports;
+	if (!strcmp (name, "libSystem.Security.Cryptography.Native.Browser"))
+		return SystemSecurityCryptographyNativeBrowserImports;
+
 	//printf("In wasm_dl_load for name %s but treating as NOT FOUND\n", name);
     return 0;
 }

--- a/src/mono/wasi/sample/SampleMakefile.variable
+++ b/src/mono/wasi/sample/SampleMakefile.variable
@@ -14,5 +14,5 @@ ifndef DOTNET_ROOT
 $(error DOTNET_ROOT is undefined. Example: export DOTNET_ROOT=~/dotnet7)
 endif
 ifndef BROWSER_WASM_RUNTIME_PATH
-$(error BROWSER_WASM_RUNTIME_PATH is undefined. Example: export BROWSER_WASM_RUNTIME_PATH=$(DOTNET_ROOT)/packs/Microsoft.NETCore.App.Runtime.Mono.browser-wasm/7.0.0-alpha.1.22061.11/runtimes/browser-wasm)
+$(error BROWSER_WASM_RUNTIME_PATH is undefined. Example: export BROWSER_WASM_RUNTIME_PATH=$(DOTNET_ROOT)/packs/Microsoft.NETCore.App.Runtime.Mono.browser-wasm/7.0.0-preview.3.22151.6/runtimes/browser-wasm)
 endif

--- a/src/mono/wasi/sample/SampleMakefile.variable
+++ b/src/mono/wasi/sample/SampleMakefile.variable
@@ -14,5 +14,5 @@ ifndef DOTNET_ROOT
 $(error DOTNET_ROOT is undefined. Example: export DOTNET_ROOT=~/dotnet7)
 endif
 ifndef BROWSER_WASM_RUNTIME_PATH
-$(error BROWSER_WASM_RUNTIME_PATH is undefined. Example: export BROWSER_WASM_RUNTIME_PATH=$(DOTNET_ROOT)/packs/Microsoft.NETCore.App.Runtime.Mono.browser-wasm/7.0.0-preview.3.22151.6/runtimes/browser-wasm)
+$(error BROWSER_WASM_RUNTIME_PATH is undefined. Example: export BROWSER_WASM_RUNTIME_PATH=$(DOTNET_ROOT)/packs/Microsoft.NETCore.App.Runtime.Mono.browser-wasm/7.0.0-alpha.1.22061.11/runtimes/browser-wasm)
 endif


### PR DESCRIPTION
With all the other runtime changes, there are a few further updates needed inside `src/mono/wasi` to have things work end-to-end with ASP.NET Core applications.

Would it be OK to include these in your `debug_wasi` PR so it all goes into `main` as one unit?